### PR TITLE
Fix: mem crash before rendering 

### DIFF
--- a/Modules/AppCoordinator/Sources/AppDIContainer.swift
+++ b/Modules/AppCoordinator/Sources/AppDIContainer.swift
@@ -64,7 +64,7 @@ public final class AppDIContainer {
             return MainActor.assumeIsolated {
                 SignupViewModel(userUseCase: useCase)
             }
-        }
+        } .inObjectScope(.container)
         
         container.register(LoginViewModel.self) { r in
             print("🧩 [DI] Register: LoginViewModel")

--- a/Modules/Features/Signup/Sources/Signup/SignupView.swift
+++ b/Modules/Features/Signup/Sources/Signup/SignupView.swift
@@ -47,7 +47,6 @@ public enum SignupStep: Int, CaseIterable {
 }
 
 public struct SignupView: View {
-    @State private var currentStep: SignupStep = .idInput
     @StateObject public var viewModel: SignupViewModel
     
     @EnvironmentObject private var router: AppRouter
@@ -62,18 +61,18 @@ public struct SignupView: View {
             signupHeaderView
 
             Group {
-                switch currentStep {
+                switch viewModel.currentStep {
                 case .phoneVerification:
-                    PhoneVerificationView(viewModel: viewModel, nextStep: nextStep)
+                    PhoneVerificationView(viewModel: viewModel)
                         .environmentObject(router)
 
 
                 case .idInput:
-                    IDInputView(viewModel: viewModel, nextStep: nextStep)
+                    IDInputView(viewModel: viewModel)
                      
 
                 case .pwInput:
-                    PwInputView(viewModel: viewModel, nextStep: nextStep)
+                    PwInputView(viewModel: viewModel)
                      
 
                 case .enterProfile:
@@ -88,23 +87,21 @@ public struct SignupView: View {
                        
                 }
             }
-            .animation(.easeInOut, value: currentStep)
+            .animation(.easeInOut, value: viewModel.currentStep)
             .interactiveDismissDisabled()
         }
         .ignoresSafeArea(.keyboard)
     }
 
     private func nextStep() {
-        if let next = SignupStep(rawValue: currentStep.rawValue + 1) {
-            currentStep = next
-        }
+        viewModel.goToNextStep()
     }
 
     private func previousStepOrExit() {
-        if currentStep == .phoneVerification {
+        if viewModel.currentStep == .phoneVerification {
             router.pop()
-        } else if let prev = SignupStep(rawValue: currentStep.rawValue - 1) {
-            currentStep = prev
+        } else {
+            viewModel.goToPreviousStep()
         }
     }
 
@@ -120,7 +117,7 @@ public struct SignupView: View {
 
                 Spacer()
 
-                Text(currentStep.title)
+                Text(viewModel.currentStep.title)
                     .font(.hanSansNeo(16, .bold))
                     .foregroundColor(.black)
                     .frame(height: 44)
@@ -141,11 +138,14 @@ public struct SignupView: View {
 
                     Rectangle()
                         .fill(Color.primaryNormal)
-                        .frame(width: geometry.size.width * currentStep.progressValue, height: 4)
-                        .animation(.easeInOut(duration: 0.2), value: currentStep)
+                        .frame(width: geometry.size.width * viewModel.currentStep.progressValue, height: 4)
+                        .animation(.easeInOut(duration: 0.2), value: viewModel.currentStep)
                 }
             }
             .frame(height: 4)
+        }
+        .onAppear {
+            print("🧩 SignupViewModel address: \(Unmanaged.passUnretained(viewModel).toOpaque())")
         }
         .navigationBarHidden(true)
     }

--- a/Modules/Features/Signup/Sources/Signup/SignupViewModel.swift
+++ b/Modules/Features/Signup/Sources/Signup/SignupViewModel.swift
@@ -57,14 +57,25 @@ final public class SignupViewModel: ObservableObject {
     
     @Published public var user: User?
     
-    
-    
-    
-    
 
     public init(userUseCase: UserUseCase) {
         self.userUseCase = userUseCase
     }
+    
+    public func goToNextStep() {
+        if let next = SignupStep(rawValue: currentStep.rawValue + 1) {
+            currentStep = next
+        }
+    }
+    
+    public func goToPreviousStep() {
+        if let prev = SignupStep(rawValue: currentStep.rawValue - 1) {
+            currentStep = prev
+        }
+    }
+    
+    
+    
 
     public func sendVerificationCode() {
         guard resendFailureCount < 3 else {

--- a/Modules/Features/Signup/Sources/Signup/Step/IDInputView.swift
+++ b/Modules/Features/Signup/Sources/Signup/Step/IDInputView.swift
@@ -16,13 +16,10 @@ public struct IDInputView: View {
     @FocusState private var isIDFocused: Bool
     
     
-    var nextStep: () -> Void
-    
     @ObservedObject private var viewModel: SignupViewModel
     
-    public init(viewModel: SignupViewModel, nextStep: @escaping () -> Void) {
+    public init(viewModel: SignupViewModel) {
             self.viewModel = viewModel
-            self.nextStep = nextStep
         }
     
     public var body: some View {
@@ -73,8 +70,8 @@ public struct IDInputView: View {
             .ignoresSafeArea(.keyboard)
             
             Button(action: {
-                print("중복검사")
-                nextStep()
+                print("✅ 버튼 클릭됨 - 현재 step: \(viewModel.currentStep)")
+                    viewModel.goToNextStep()
             }) {
                 Text("다음")
                     .font(.hanSansNeo(14, .bold))
@@ -83,6 +80,9 @@ public struct IDInputView: View {
                     .background(viewModel.isIDAvailable ?? false ? Color.primaryNormal : Color(hex: "#EBEBEB"))
                     .foregroundColor(.white)
                     .cornerRadius(4)
+            }
+            .onAppear {
+                print("✅ PwInputView 진입")
             }
             .ignoresSafeArea(.keyboard)
             .disabled(!(viewModel.isIDAvailable ?? true))

--- a/Modules/Features/Signup/Sources/Signup/Step/PhoneVerificationView.swift
+++ b/Modules/Features/Signup/Sources/Signup/Step/PhoneVerificationView.swift
@@ -24,16 +24,14 @@ public struct PhoneVerificationView: View {
     @EnvironmentObject private var router: AppRouter
     
     
-    var nextStep: () -> Void
 
     @FocusState private var isPhoneFieldFocused: Bool
     @FocusState private var isNumberPadFocused: Bool
 
     @ObservedObject private var viewModel: SignupViewModel
     
-    public init(viewModel: SignupViewModel, nextStep: @escaping () -> Void) {
+    public init(viewModel: SignupViewModel) {
             self.viewModel = viewModel
-            self.nextStep = nextStep
         }
 
     public var body: some View {
@@ -146,7 +144,7 @@ public struct PhoneVerificationView: View {
             if viewModel.isRequestSent {
                 Button(action: {
                     if viewModel.verifyCode() {
-                        nextStep()
+                        viewModel.goToNextStep()
                     }
                 }) {
                     Text("다음")

--- a/Modules/Features/Signup/Sources/Signup/Step/PwInputView.swift
+++ b/Modules/Features/Signup/Sources/Signup/Step/PwInputView.swift
@@ -16,14 +16,11 @@ public struct PwInputView: View {
     @FocusState private var isPasswordFocused: Bool
     @FocusState private var isConfirmPasswordFocused: Bool
 
-    
-    var nextStep: () -> Void
 
     @ObservedObject private var viewModel: SignupViewModel
     
-    public init(viewModel: SignupViewModel, nextStep: @escaping () -> Void) {
+    public init(viewModel: SignupViewModel) {
             self.viewModel = viewModel
-            self.nextStep = nextStep
         }
 
     public var body: some View {
@@ -88,7 +85,7 @@ public struct PwInputView: View {
             .hideKeyboardOnTap()
 
             Button(action: {
-                nextStep()
+                viewModel.goToNextStep()
             }) {
                 Text("다음")
                     .font(.hanSansNeo(14,.bold))
@@ -100,9 +97,9 @@ public struct PwInputView: View {
                     .contentShape(Rectangle())
                 
             }
-            disabled(!viewModel.isPasswordValid)
-                .padding(.horizontal, 24)
-                .padding(.bottom, 20)
+            .padding(.horizontal, 24)
+            .padding(.bottom, 20)
+            .disabled(!viewModel.isPasswordValid)
         }
 
     }

--- a/Newdok.xcworkspace/xcuserdata/minjae.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
+++ b/Newdok.xcworkspace/xcuserdata/minjae.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
@@ -23,38 +23,6 @@
       <BreakpointProxy
          BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
          <BreakpointContent
-            uuid = "A6451CA7-07EA-4D7F-83DE-A825879F9517"
-            shouldBeEnabled = "No"
-            ignoreCount = "0"
-            continueAfterRunningActions = "No"
-            filePath = "Modules/Features/Signup/Sources/Signup/Step/IDInputView.swift"
-            startingColumnNumber = "9223372036854775807"
-            endingColumnNumber = "9223372036854775807"
-            startingLineNumber = "77"
-            endingLineNumber = "77"
-            landmarkName = "body"
-            landmarkType = "24">
-         </BreakpointContent>
-      </BreakpointProxy>
-      <BreakpointProxy
-         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
-         <BreakpointContent
-            uuid = "C6944176-7311-4153-A2D1-E1D521D60D47"
-            shouldBeEnabled = "No"
-            ignoreCount = "0"
-            continueAfterRunningActions = "No"
-            filePath = "Modules/Features/Signup/Sources/Signup/Step/IDInputView.swift"
-            startingColumnNumber = "9223372036854775807"
-            endingColumnNumber = "9223372036854775807"
-            startingLineNumber = "76"
-            endingLineNumber = "76"
-            landmarkName = "body"
-            landmarkType = "24">
-         </BreakpointContent>
-      </BreakpointProxy>
-      <BreakpointProxy
-         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
-         <BreakpointContent
             uuid = "BD46A813-6F0C-446A-AF70-A92064C86F24"
             shouldBeEnabled = "No"
             ignoreCount = "0"
@@ -62,8 +30,8 @@
             filePath = "Modules/Features/Signup/Sources/Signup/Step/IDInputView.swift"
             startingColumnNumber = "9223372036854775807"
             endingColumnNumber = "9223372036854775807"
-            startingLineNumber = "75"
-            endingLineNumber = "75"
+            startingLineNumber = "72"
+            endingLineNumber = "72"
             landmarkName = "body"
             landmarkType = "24">
          </BreakpointContent>
@@ -78,8 +46,8 @@
             filePath = "Modules/Features/Signup/Sources/Signup/Step/PwInputView.swift"
             startingColumnNumber = "9223372036854775807"
             endingColumnNumber = "9223372036854775807"
-            startingLineNumber = "114"
-            endingLineNumber = "114"
+            startingLineNumber = "111"
+            endingLineNumber = "111"
             landmarkName = "isPasswordValid"
             landmarkType = "24">
          </BreakpointContent>


### PR DESCRIPTION
Avoid applying .disabled() outside of Button; it can cause SwiftUI to crash during view composition, especially with @FocusState or modifiers.
Scoped the .disabled() directly to the Button to ensure safe and predictable behavior.