### PR TITLE
Fix search parameter and provider name

### DIFF
--- a/Modules/AppCoordinator/Sources/AppDIContainer.swift
+++ b/Modules/AppCoordinator/Sources/AppDIContainer.swift
@@ -55,7 +55,7 @@ public final class AppDIContainer {
         
         container.register(MoyaProvider<ArticleAPI>.self) { r in
             let network = r.resolve(NetworkProviding.self)!
-            return network.mekeArticleProvider()
+            return network.makeArticleProvider()
         }.inObjectScope(.container)
         
         // MARK: - Repository

--- a/Modules/Core/Sources/API/ArticleAPI.swift
+++ b/Modules/Core/Sources/API/ArticleAPI.swift
@@ -74,7 +74,7 @@ extension ArticleAPI: TargetType {
         case .fetchBookmarkedInterest:
             return .requestPlain
         case .search(let word):
-            return .requestParameters(parameters: ["ketword": word], encoding: URLEncoding.default)
+            return .requestParameters(parameters: ["keyword": word], encoding: URLEncoding.default)
         case .fetchArticleDetail:
             return .requestPlain
         }

--- a/Modules/Core/Sources/Network/NetworkProvider.swift
+++ b/Modules/Core/Sources/Network/NetworkProvider.swift
@@ -12,7 +12,7 @@ import Shared
 
 public protocol NetworkProviding {
     func makeAuthProvider() -> MoyaProvider<UserAPI>
-    func mekeArticleProvider() -> MoyaProvider<ArticleAPI>
+    func makeArticleProvider() -> MoyaProvider<ArticleAPI>
     func makeNewsletterProvider() -> MoyaProvider<NewsletterAPI>
 }
 
@@ -35,7 +35,7 @@ public final class NetworkProvider: NetworkProviding {
         )
     }
     
-    public func mekeArticleProvider() -> MoyaProvider<ArticleAPI> {
+    public func makeArticleProvider() -> MoyaProvider<ArticleAPI> {
         return MoyaProvider<ArticleAPI>(
             session: makeSafeSession(),
             plugins: [


### PR DESCRIPTION
## Summary
- correct `keyword` parameter in `ArticleAPI`
- rename `mekeArticleProvider` to `makeArticleProvider`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684ea7d753d8832a9fb045f3257faadc