### PR TITLE
Fix calendar month navigation

### DIFF
--- a/Modules/DesignSystem/Sources/Component/CalendarPopupView.swift
+++ b/Modules/DesignSystem/Sources/Component/CalendarPopupView.swift
@@ -7,7 +7,6 @@
 
 import SwiftUI
 import UIKit
-import Domain
 
 struct RoundedCorners: Shape {
     var radius: CGFloat = 16
@@ -27,9 +26,8 @@ public struct CalendarPopupView: View {
     @State private var selectedDate = Date()
     @State private var displayedMonthDate = Date()
     
-    public var monthlyData: [Articles]
-
     public var onDateSelected: ((Date) -> Void)?
+    public var onMonthChanged: ((Date) -> Void)?
     /// 데이터가 있는 날짜를 외부에서 전달 받습니다.
     public var dataDates: Set<Date>
 
@@ -44,13 +42,13 @@ public struct CalendarPopupView: View {
         isPresented: Binding<Bool>,
         dataDates: Set<Date> = [],
         onDateSelected: ((Date) -> Void)? = nil,
-        monthlyData: [Articles] = []
+        onMonthChanged: ((Date) -> Void)? = nil
     ) {
         self._isPresented = isPresented
         self.dataDates = dataDates.map { Calendar.current.startOfDay(for: $0) }
             .reduce(into: []) { $0.insert($1) }
         self.onDateSelected = onDateSelected
-        self.monthlyData = monthlyData
+        self.onMonthChanged = onMonthChanged
     }
 
     public var body: some View {
@@ -214,10 +212,12 @@ public struct CalendarPopupView: View {
 
     private func previousMonth() {
         displayedMonthDate = calendar.date(byAdding: .month, value: -1, to: displayedMonthDate)!
+        onMonthChanged?(displayedMonthDate)
     }
 
     private func nextMonth() {
         displayedMonthDate = calendar.date(byAdding: .month, value: 1, to: displayedMonthDate)!
+        onMonthChanged?(displayedMonthDate)
     }
 
     private func isSameDay(_ date1: Date, _ date2: Date) -> Bool {

--- a/Modules/Features/Home/Sources/Home/HomeView.swift
+++ b/Modules/Features/Home/Sources/Home/HomeView.swift
@@ -57,7 +57,10 @@ public struct HomeView: View {
                                 viewModel.filterArticles(by: date)
                                 showCalendar = false
                             }
-                        }, monthlyData: viewModel.articlesByMonth
+                        },
+                        onMonthChanged: { date in
+                            Task { await viewModel.loadArticles(for: date) }
+                        }
                     )
                 } customize: {
             $0

--- a/Modules/Features/Home/Sources/Home/HomeViewModel.swift
+++ b/Modules/Features/Home/Sources/Home/HomeViewModel.swift
@@ -43,14 +43,15 @@ public final class HomeViewModel: ObservableObject {
     
     
     public var articlesByMonthDates: Set<Date> {
-            let calendar = Calendar.current
-            // selectedDate 의 연·월 컴포넌트만 살리고, publishDate(Int day)만 교체
-            let comps = calendar.dateComponents([.year, .month], from: selectedDate)
-            return Set(articlesByMonth.compactMap { articleGroup in
-                var dc = comps
-                dc.day = articleGroup.publishDate
-                return calendar.date(from: dc)
-            })
+        let calendar = Calendar.current
+        // selectedDate 의 연·월 컴포넌트만 살리고, publishDate(Int day)만 교체
+        let comps = calendar.dateComponents([.year, .month], from: selectedDate)
+        return Set(articlesByMonth.compactMap { articleGroup in
+            guard !articleGroup.receivedArticleList.isEmpty else { return nil }
+            var dc = comps
+            dc.day = articleGroup.publishDate
+            return calendar.date(from: dc)
+        })
         }
     
     


### PR DESCRIPTION
## Summary
- refine calendar popup interface
- refresh monthly data when navigating months
- only mark dates with data

## Testing
- `swiftc -typecheck Modules/DesignSystem/Sources/Component/CalendarPopupView.swift` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_6866a3180e74832aa1a9c8ffb6f78aa2