### PR TITLE
Fix calendar not staying open

### DIFF
--- a/Modules/DesignSystem/Sources/Component/CalendarPopupView.swift
+++ b/Modules/DesignSystem/Sources/Component/CalendarPopupView.swift
@@ -7,7 +7,6 @@
 
 import SwiftUI
 import UIKit
-import Domain
 
 struct RoundedCorners: Shape {
     var radius: CGFloat = 16
@@ -27,9 +26,8 @@ public struct CalendarPopupView: View {
     @State private var selectedDate = Date()
     @State private var displayedMonthDate = Date()
     
-    public var monthlyData: [Articles]
-
     public var onDateSelected: ((Date) -> Void)?
+    public var onMonthChanged: ((Date) -> Void)?
     /// 데이터가 있는 날짜를 외부에서 전달 받습니다.
     public var dataDates: Set<Date>
 
@@ -44,13 +42,13 @@ public struct CalendarPopupView: View {
         isPresented: Binding<Bool>,
         dataDates: Set<Date> = [],
         onDateSelected: ((Date) -> Void)? = nil,
-        monthlyData: [Articles] = []
+        onMonthChanged: ((Date) -> Void)? = nil
     ) {
         self._isPresented = isPresented
         self.dataDates = dataDates.map { Calendar.current.startOfDay(for: $0) }
             .reduce(into: []) { $0.insert($1) }
         self.onDateSelected = onDateSelected
-        self.monthlyData = monthlyData
+        self.onMonthChanged = onMonthChanged
     }
 
     public var body: some View {
@@ -214,10 +212,12 @@ public struct CalendarPopupView: View {
 
     private func previousMonth() {
         displayedMonthDate = calendar.date(byAdding: .month, value: -1, to: displayedMonthDate)!
+        onMonthChanged?(displayedMonthDate)
     }
 
     private func nextMonth() {
         displayedMonthDate = calendar.date(byAdding: .month, value: 1, to: displayedMonthDate)!
+        onMonthChanged?(displayedMonthDate)
     }
 
     private func isSameDay(_ date1: Date, _ date2: Date) -> Bool {

--- a/Modules/Features/Home/Sources/Home/HomeView.swift
+++ b/Modules/Features/Home/Sources/Home/HomeView.swift
@@ -57,7 +57,14 @@ public struct HomeView: View {
                                 viewModel.filterArticles(by: date)
                                 showCalendar = false
                             }
-                        }, monthlyData: viewModel.articlesByMonth
+                        },
+                        onMonthChanged: { date in
+                            Task {
+                                await viewModel.loadArticles(for: date)
+                                // 월을 변경해도 팝업이 닫히지 않도록 유지합니다.
+                                showCalendar = true
+                            }
+                        }
                     )
                 } customize: {
             $0

--- a/Modules/Features/Home/Sources/Home/HomeViewModel.swift
+++ b/Modules/Features/Home/Sources/Home/HomeViewModel.swift
@@ -38,20 +38,23 @@ public final class HomeViewModel: ObservableObject {
     @Published public var subscribedNewsletters: [Newsletter] = []
     @Published public var articlesByMonth: [Articles] = []
     @Published public var selectedDate: Date = Date()
+    /// 현재 로드된 월을 저장합니다.
+    @Published public var currentMonthDate: Date = Date()
     
     @AppStorage("isGuest") public var isGuest: Bool = false
     
     
     public var articlesByMonthDates: Set<Date> {
-            let calendar = Calendar.current
-            // selectedDate 의 연·월 컴포넌트만 살리고, publishDate(Int day)만 교체
-            let comps = calendar.dateComponents([.year, .month], from: selectedDate)
-            return Set(articlesByMonth.compactMap { articleGroup in
-                var dc = comps
-                dc.day = articleGroup.publishDate
-                return calendar.date(from: dc)
-            })
-        }
+        let calendar = Calendar.current
+        // 현재 로드된 월의 연·월 컴포넌트만 사용하고, 일 정보만 교체합니다.
+        let comps = calendar.dateComponents([.year, .month], from: currentMonthDate)
+        return Set(articlesByMonth.compactMap { articleGroup in
+            guard !articleGroup.receivedArticleList.isEmpty else { return nil }
+            var dc = comps
+            dc.day = articleGroup.publishDate
+            return calendar.date(from: dc)
+        })
+    }
     
     
     var homeState: HomeState {
@@ -86,6 +89,7 @@ public final class HomeViewModel: ObservableObject {
             let data = try await useCase.fetchTodayData()
             self.filteredArticles = data.articles
             self.subscribedNewsletters = data.activeNewsletters
+            self.currentMonthDate = Date()
         } catch {
             print("today fetch error: \(error)")
         }
@@ -95,11 +99,13 @@ public final class HomeViewModel: ObservableObject {
     public func loadArticles(for date: Date) async {
         let year = formatYear(date)
         let month = formatMonth(date)
-        
+
         do {
             let monthly = try await useCase.fetchMonthlyData(year: year, month: month)
             self.articlesByMonth = monthly
-            self.filterArticles(by: date)
+            self.currentMonthDate = date
+            // 기존 선택된 날짜 기준으로 필터링을 유지합니다.
+            self.filterArticles(by: selectedDate)
         } catch {
             print("❌ Monthly fetch failed: \(error)")
         }


### PR DESCRIPTION
## Summary
- track the month currently loaded in `HomeViewModel`
- keep calendar popup visible when switching months

## Testing
- `swiftc -typecheck Modules/DesignSystem/Sources/Component/CalendarPopupView.swift` *(fails: no such module 'SwiftUI')*
- `swiftc -typecheck Modules/Features/Home/Sources/Home/HomeViewModel.swift` *(fails: no such module 'SwiftUI')*
- `swiftc -typecheck Modules/Features/Home/Sources/Home/HomeView.swift` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_6866a3180e74832aa1a9c8ffb6f78aa2