### PR TITLE
Link no-articles view to Explore tab

### DIFF
--- a/Modules/AppCoordinator/Sources/Flow/NewDokTabView.swift
+++ b/Modules/AppCoordinator/Sources/Flow/NewDokTabView.swift
@@ -82,6 +82,7 @@ public struct NewDokTabView: View {
                 .background(Color.white)
         }
         .environmentObject(tabSelection)
+        .environmentObject(exploreViewModel)
         .background(Color.white)
     }
 }

--- a/Modules/Features/Explore/Sources/Explore/ExploreView.swift
+++ b/Modules/Features/Explore/Sources/Explore/ExploreView.swift
@@ -11,13 +11,10 @@ import Shared
 import Lottie 
 
 public struct ExploreView: View {
-    @State private var selectedTab: Int = 0 // 0: 추천, 1: 전체
-    @State private var currentPage: Int = 0
-    
-    
-    @State private var isLoaded: Bool = false
-
+    // ViewModel에서 탭 상태를 관리하도록 수정
     @StateObject private var viewModel: ExploreViewModel
+    @State private var currentPage: Int = 0
+    @State private var isLoaded: Bool = false
     @EnvironmentObject private var router: AppRouter
     
     
@@ -38,7 +35,7 @@ public struct ExploreView: View {
                 
                 if isGuest {
                     Group {
-                        if selectedTab == 0 {
+                        if viewModel.selectedTab == 0 {
                             ScrollView(showsIndicators: false) {
                                 allNewsletterSection
                             }
@@ -48,7 +45,7 @@ public struct ExploreView: View {
                     }
                 } else {
                     Group {
-                        if selectedTab == 0 {
+                        if viewModel.selectedTab == 0 {
                             if !isLoaded {
                                 EmptyView() //후에 로딩뷰
                             } else if !viewModel.hasUserProfile {
@@ -142,8 +139,8 @@ public struct ExploreView: View {
                 Rectangle()
                     .fill(Color(hex: "#363636"))
                     .frame(width: width, height: 2)
-                    .offset(x: selectedTab == 0 ? 0 : width)
-                    .animation(.easeInOut(duration: 0.3), value: selectedTab)
+                    .offset(x: viewModel.selectedTab == 0 ? 0 : width)
+                    .animation(.easeInOut(duration: 0.3), value: viewModel.selectedTab)
             }
             .frame(height: 2)
         }
@@ -439,11 +436,11 @@ public struct ExploreView: View {
     @ViewBuilder
     private func tabButton(title: String, index: Int) -> some View {
         Button(action: {
-            selectedTab = index
+            viewModel.selectedTab = index
         }) {
             Text(title)
                 .font(.hanSansNeo(14, .bold))
-                .foregroundColor(selectedTab == index ? Color(hex: "#363636") : Color(hex: "#767676"))
+                .foregroundColor(viewModel.selectedTab == index ? Color(hex: "#363636") : Color(hex: "#767676"))
                 .frame(maxWidth: .infinity)
                 .padding(.vertical, 12)
         }

--- a/Modules/Features/Explore/Sources/Explore/ExploreViewModel.swift
+++ b/Modules/Features/Explore/Sources/Explore/ExploreViewModel.swift
@@ -19,6 +19,9 @@ public class ExploreViewModel: ObservableObject {
     @Published public var unionRecommendation: [NewsletterDetail] = []
     
     @Published public var allNewsletters: [Brand] = []
+
+    // 현재 선택된 탭 (0: 추천, 1: 전체)
+    @Published public var selectedTab: Int = 0
     
     @Published public var orderOpt: String? = "인기순"
     @Published public var industry: [Int]? = nil

--- a/Modules/Features/Home/Sources/Home/HomeView.swift
+++ b/Modules/Features/Home/Sources/Home/HomeView.swift
@@ -21,6 +21,7 @@ public struct HomeView: View {
     @State private var showCalendar = false
     @State private var calendarDisplayedMonth = Date()
     @EnvironmentObject private var router: AppRouter
+    @EnvironmentObject private var exploreViewModel: ExploreViewModel
     @AppStorage("isGuest") private var isGuest: Bool = false
     public init(viewModel: HomeViewModel) {
         _viewModel = StateObject(wrappedValue: viewModel)
@@ -137,7 +138,20 @@ public struct HomeView: View {
                     tabSelection.selectedTab = .explore
                 })
             case .noArticles:
-                NoDataView(type: .noArticles, buttonAction: {})
+                NoDataView(type: .noArticles, buttonAction: {
+                    let weekday = Calendar.current.component(.weekday, from: viewModel.selectedDate)
+                    let dayIndex = convertWeekdayToExploreIndex(weekday)
+                    exploreViewModel.day = [dayIndex]
+                    exploreViewModel.selectedTab = 1
+                    Task {
+                        if isGuest {
+                            await exploreViewModel.fetchGuestAllNewsletters()
+                        } else {
+                            await exploreViewModel.fetchAllNewsletters()
+                        }
+                    }
+                    tabSelection.selectedTab = .explore
+                })
             case .articles:
                 articlesSection
             }
@@ -185,5 +199,18 @@ public struct HomeView: View {
         .background(
             Color.white.clipShape(RoundedRectangle(cornerRadius: 12))
         )
+    }
+
+    private func convertWeekdayToExploreIndex(_ weekday: Int) -> Int {
+        switch weekday {
+        case 1: return 7 // Sunday
+        case 2: return 1 // Monday
+        case 3: return 2
+        case 4: return 3
+        case 5: return 4
+        case 6: return 5
+        case 7: return 6
+        default: return 8
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add `selectedTab` to `ExploreViewModel`
- drive `ExploreView` tab state from the view model
- expose `ExploreViewModel` to subviews via environment
- when home shows no articles, jump to Explore's all newsletters filtered by the selected day

## Testing
- `swift build` *(fails: Could not find Package.swift)*
- `swiftformat` *(fails: command not found)*
- `swiftlint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6871f71b5414832a9b3ac538355e332d