### PR TITLE
Integrate App module with coordinator

### DIFF
--- a/Modules/App/Project.swift
+++ b/Modules/App/Project.swift
@@ -15,11 +15,8 @@ let project = Project(
             dependencies: [
                 .project(target: "Core", path: "../Core"),
                 .project(target: "DesignSystem", path: "../DesignSystem"),
-                .project(target: "Auth", path: "../Features/Auth"),
-                .project(target: "Home", path: "../Features/Home"),
-                .project(target: "Launch", path: "../Features/Launch"),
-                .project(target: "Signup", path: "../Features/Signup"),
-                .project(target: "Survey", path: "../Features/Survey"),
+                .project(target: "AppCoordinator", path: "../AppCoordinator"),
+                .project(target: "Shared", path: "../Shared"),
             ]
         )
     ]

--- a/Modules/App/Sources/NewdokApp.swift
+++ b/Modules/App/Sources/NewdokApp.swift
@@ -8,6 +8,8 @@
 import SwiftUI
 import Core
 import Shared
+import AppCoordinator
+import DesignSystem
 
 @main
 struct NewdokApp: App {
@@ -15,23 +17,29 @@ struct NewdokApp: App {
     @State private var showUpdateAlert = false
     @StateObject private var router = AppRouter()
     @StateObject private var tabSelection = TabSelection()
-    
+
+    init() {
+        DesignSystemFontFamily.registerAllCustomFonts()
+    }
+
     var body: some Scene {
         WindowGroup {
-            ContentView()
-                .environmentObject(router)
-                .environmentObject(tabSelection)
-                .onAppear(perform: checkVersion)
-                .alert(isPresented: $showUpdateAlert) {
-                    Alert(
-                        title: Text("업데이트 안내"),
-                        message: Text("새로운 버전이 출시되었습니다. 스토어로 이동하여 업데이트를 진행해주세요."),
-                        primaryButton: .default(Text("업데이트"), action: {
-                            openAppStore()
-                        }),
-                        secondaryButton: .cancel(Text("나중에"))
-                    )
-                }
+            OverlayRootView {
+                AppCoordinatorEntry.makeAFlow()
+            }
+            .environmentObject(router)
+            .environmentObject(tabSelection)
+            .onAppear(perform: checkVersion)
+            .alert(isPresented: $showUpdateAlert) {
+                Alert(
+                    title: Text("업데이트 안내"),
+                    message: Text("새로운 버전이 출시되었습니다. 스토어로 이동하여 업데이트를 진행해주세요."),
+                    primaryButton: .default(Text("업데이트"), action: {
+                        openAppStore()
+                    }),
+                    secondaryButton: .cancel(Text("나중에"))
+                )
+            }
         }
     }
     


### PR DESCRIPTION
## Summary
- use `AppCoordinatorEntry` in `NewdokApp`
- add `AppCoordinator` and `Shared` to App target dependencies

## Testing
- `swift --version`


------
https://chatgpt.com/codex/tasks/task_e_687218f86334832aaea3df02001d255a