### PR TITLE
Use AppRouter to navigate to Explore with day filter

### DIFF
--- a/Modules/AppCoordinator/Sources/Container/AppCoordinator.swift
+++ b/Modules/AppCoordinator/Sources/Container/AppCoordinator.swift
@@ -54,7 +54,7 @@ final class AppCoordinator {
         let vm = container.container.resolve(ExploreViewModel.self)!
         return ExploreView(viewModel: vm).environmentObject(router)
     }
-    func makeTabView() -> some View {
+    func makeTabView(selectedTab: NewDokTab? = nil, exploreDay: Int? = nil, exploreSelectedTab: Int? = nil) -> some View {
         
         let homeVm = container.container.resolve(HomeViewModel.self)!
         let exploreVm = container.container.resolve(ExploreViewModel.self)!
@@ -67,7 +67,10 @@ final class AppCoordinator {
             exploreViewModel: exploreVm,
             subscribeViewModel: subscribeVm,
             bookmarkViewModel: bookmakrVm,
-            mypageViewModel: mypageVm
+            mypageViewModel: mypageVm,
+            selectedTab: selectedTab,
+            exploreDay: exploreDay,
+            exploreSelectedTab: exploreSelectedTab
         ).environmentObject(router)
     }
     func mekeProfileView() -> some View {

--- a/Modules/AppCoordinator/Sources/Flow/AuthFlow/QABFlowCoordinatorView.swift
+++ b/Modules/AppCoordinator/Sources/Flow/AuthFlow/QABFlowCoordinatorView.swift
@@ -42,8 +42,8 @@ struct QABRootView: View {
                         coordinator.makeLoginView()
                     case .home:
                         coordinator.makeHomeView()
-                    case .tabbar:
-                        coordinator.makeTabView()
+                    case let .tabbar(selectedTab, exploreDay, exploreSelectedTab):
+                        coordinator.makeTabView(selectedTab: selectedTab, exploreDay: exploreDay, exploreSelectedTab: exploreSelectedTab)
                     case .profile:
                         coordinator.mekeProfileView()
                     case .explore:
@@ -79,8 +79,8 @@ struct QABRootView: View {
                         coordinator.makeLoginView()
                     case .home:
                         coordinator.makeHomeView()
-                    case .tabbar:
-                        coordinator.makeTabView()
+                    case let .tabbar(selectedTab, exploreDay, exploreSelectedTab):
+                        coordinator.makeTabView(selectedTab: selectedTab, exploreDay: exploreDay, exploreSelectedTab: exploreSelectedTab)
                     case .profile:
                         coordinator.mekeProfileView()
                     case .explore:

--- a/Modules/AppCoordinator/Sources/Flow/NewDokTabView.swift
+++ b/Modules/AppCoordinator/Sources/Flow/NewDokTabView.swift
@@ -30,18 +30,28 @@ public struct NewDokTabView: View {
     private let bookmarkViewModel: BookmarkViewModel
     private let mypageViewModel: MypageViewModel
 
+    private let initialSelectedTab: NewDokTab?
+    private let exploreDay: Int?
+    private let exploreSelectedTab: Int?
+
     public init(
         homeViewModel: HomeViewModel,
         exploreViewModel: ExploreViewModel,
         subscribeViewModel: SubscribeViewModel,
         bookmarkViewModel: BookmarkViewModel,
-        mypageViewModel: MypageViewModel
+        mypageViewModel: MypageViewModel,
+        selectedTab: NewDokTab? = nil,
+        exploreDay: Int? = nil,
+        exploreSelectedTab: Int? = nil
     ) {
         self.homeViewModel = homeViewModel
         self.exploreViewModel = exploreViewModel
         self.subscribeViewModel = subscribeViewModel
         self.bookmarkViewModel = bookmarkViewModel
         self.mypageViewModel = mypageViewModel
+        self.initialSelectedTab = selectedTab
+        self.exploreDay = exploreDay
+        self.exploreSelectedTab = exploreSelectedTab
     }
     
     public var body: some View {
@@ -83,6 +93,17 @@ public struct NewDokTabView: View {
         }
         .environmentObject(tabSelection)
         .environmentObject(exploreViewModel)
+        .onAppear {
+            if let tab = initialSelectedTab {
+                tabSelection.selectedTab = tab
+            }
+            if let day = exploreDay {
+                exploreViewModel.day = [day]
+            }
+            if let selected = exploreSelectedTab {
+                exploreViewModel.selectedTab = selected
+            }
+        }
         .background(Color.white)
     }
 }

--- a/Modules/Features/Auth/Sources/Login/View/LoginView.swift
+++ b/Modules/Features/Auth/Sources/Login/View/LoginView.swift
@@ -102,8 +102,7 @@ public struct LoginView: View {
                     viewModel.login() {
                         isLoggedIn = true
                         isGuest = false
-                        tabSelection.selectedTab = .home
-                        router.resetTo(.tabbar)
+                        router.resetTo(.tabbar(selectedTab: .home))
                         print("LoginView에서 router 인스턴스: \(Unmanaged.passUnretained(router).toOpaque())")
                     }
                     
@@ -120,7 +119,7 @@ public struct LoginView: View {
                     Button("비회원으로 이용하기") {
                         isGuest = true
                         TokenStorage.clear()
-                        router.resetTo(.tabbar)
+                        router.resetTo(.tabbar(selectedTab: .home))
                     }
                     .font(.hanSansNeo(14, .medium))
                     .foregroundStyle(Color(hex: "565656"))

--- a/Modules/Features/Home/Sources/Home/HomeView.swift
+++ b/Modules/Features/Home/Sources/Home/HomeView.swift
@@ -15,8 +15,6 @@ import Lottie
 
 
 public struct HomeView: View {
-    
-    @EnvironmentObject private var tabSelection: TabSelection
     @StateObject private var viewModel: HomeViewModel
     @State private var showCalendar = false
     @State private var calendarDisplayedMonth = Date()
@@ -135,14 +133,13 @@ public struct HomeView: View {
                 )
             case .noSubscriptions:
                 NoDataView(type: .noSubscriptions, buttonAction: {
-                    tabSelection.selectedTab = .explore
+                    router.resetTo(.tabbar(selectedTab: .explore))
                 })
             case .noArticles:
                 NoDataView(type: .noArticles, buttonAction: {
                     let weekday = Calendar.current.component(.weekday, from: viewModel.selectedDate)
                     let dayIndex = convertWeekdayToExploreIndex(weekday)
-                    router.push(.explore(day: dayIndex, selectedTab: 1))
-                    tabSelection.selectedTab = .explore
+                    router.resetTo(.tabbar(selectedTab: .explore, exploreDay: dayIndex, exploreSelectedTab: 1))
                 })
             case .articles:
                 articlesSection

--- a/Modules/Features/Signup/Sources/Signup/SignupView.swift
+++ b/Modules/Features/Signup/Sources/Signup/SignupView.swift
@@ -151,7 +151,7 @@ public struct SignupView: View {
                 if viewModel.currentStep == .recommend {
                     Button(action: {
                         withAnimation(.easeInOut) {
-                            router.resetTo(.tabbar)
+                            router.resetTo(.tabbar())
                         }
                     }) {
                         Text("건너뛰기")

--- a/Modules/Shared/Sources/Router/AppRoute.swift
+++ b/Modules/Shared/Sources/Router/AppRoute.swift
@@ -12,7 +12,7 @@ public enum AppRoute: Hashable {
     case home
     case profile
     case explore(day: Int? = nil, selectedTab: Int? = nil)
-    case tabbar
+    case tabbar(selectedTab: NewDokTab? = nil, exploreDay: Int? = nil, exploreSelectedTab: Int? = nil)
     
     case brandDetail(id: String)
     case articleDetail(id: String)


### PR DESCRIPTION
## Summary
- add selected tab and filter parameters to `AppRoute.tabbar`
- propagate new parameters through `AppCoordinator` and `QABFlowCoordinatorView`
- update `NewDokTabView` to apply initial tab and filter on appear
- refactor `HomeView` to navigate via `AppRouter` instead of `TabSelection`
- update login and signup flows to use updated route API

## Testing
- `swift --version`
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6872724509b8832a8396efa8b66d0d16